### PR TITLE
Added autocompletion for the console

### DIFF
--- a/Console/Autocompletion.cs
+++ b/Console/Autocompletion.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PiTung.Console
+{
+    static class Autocompletion
+    {
+        public static IEnumerable<String> Candidates(String command, IEnumerable<String> commands)
+        {
+            return commands.Where(candidate => candidate.StartsWith(command));
+        }
+    }
+}

--- a/Console/Autocompletion.cs
+++ b/Console/Autocompletion.cs
@@ -7,9 +7,43 @@ namespace PiTung.Console
 {
     static class Autocompletion
     {
+        /// <summary>
+        /// Returns the autocompletion candidates from the given command stub and available commands
+        /// </summary>
+        /// <param name="command">What needs to be autocompleted</param>
+        /// <param name="commands">The possible values</param>
+        /// <returns>The autocompletion candidates</returns>
         public static IEnumerable<String> Candidates(String command, IEnumerable<String> commands)
         {
             return commands.Where(candidate => candidate.StartsWith(command));
+        }
+
+        /// <summary>
+        /// Computes the longest common prefix of a list of strings
+        /// </summary>
+        /// <param name="commands"></param>
+        /// <returns>The longest common prefix of the collection of strings</returns>
+        public static String CommonPrefix(IEnumerable<String> commands)
+        {
+            return commands.Aggregate((prefix, next) => LongestCommonPrefix(prefix, next));
+        }
+
+        /// <summary>
+        /// Computes the longest common prefix of 2 strings
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns>The longest common prefix of a and b</returns>
+        private static String LongestCommonPrefix(String a, String b)
+        {
+            String result = "";
+            for (int index = 0; index < a.Length; index++)
+            {
+                if (a[index] != b[index])
+                    return result;
+                result += a[index];
+            }
+            return result;
         }
     }
 }

--- a/Console/IGConsole.cs
+++ b/Console/IGConsole.cs
@@ -702,22 +702,30 @@ namespace PiTung.Console
                 return;
             List<String> candidates =
                 new List<String>(Autocompletion.Candidates(CurrentCmd, Registry.Keys));
-            if (candidates.Count() == 0)
+
+            if (candidates.Count() == 0) // No candidate
                 return;
 
-            if (candidates.Count() == 1)
+            if (candidates.Count() == 1) // 1 candidate, autocomplete
             {
                 CurrentCmd = candidates[0] + " ";
                 EditLocation = CurrentCmd.Length;
                 return;
             }
 
+            // More than 1 candidates, complete as much as possible and
+            // display a list of candidates if necessary
+
+            String common_prefix = Autocompletion.CommonPrefix(candidates);
+            CurrentCmd = common_prefix;
+            EditLocation = CurrentCmd.Length;
+
             if (PreviousCmd == CurrentCmd)
             {
                 String list = "";
                 foreach (String candidate in candidates)
-                    list += candidate + " ";
-                Log(candidates);
+                    list += candidate + "    ";
+                Log(list);
             }
             PreviousCmd = CurrentCmd;
         }

--- a/Console/IGConsole.cs
+++ b/Console/IGConsole.cs
@@ -215,7 +215,8 @@ namespace PiTung.Console
 
             LoadCommands();
 
-            ModInput.RegisterBinding(null, "ToggleConsole", KeyCode.Tab);
+            ModInput.RegisterBinding(null, "ToggleConsole", KeyCode.BackQuote);
+            ModInput.RegisterBinding(null, "ConsoleAutocompletion", KeyCode.Tab);
 
             Initialized = true;
 
@@ -277,6 +278,9 @@ namespace PiTung.Console
 
             if (Shown)
             {
+                if (ModInput.GetKeyDown("ConsoleAutocompletion"))
+                    TriggerAutocompletion();
+
                 // Handling history
                 if (Input.GetKeyDown(KeyCode.UpArrow) && HistorySelector < History.Count - 1)
                 {
@@ -594,7 +598,7 @@ namespace PiTung.Console
                     if (CurrentCmd.Length != 0)
                     {
                         int index = EditLocation;
-                        while(index > 0 && Char.IsLetterOrDigit(CurrentCmd.ElementAt(index - 1)))
+                        while (index > 0 && Char.IsLetterOrDigit(CurrentCmd.ElementAt(index - 1)))
                             index--;
                         if (index == EditLocation && EditLocation > 0) // Delete at least 1 character
                             index--;
@@ -617,6 +621,7 @@ namespace PiTung.Console
                     CurrentCmd = "";
                     EditLocation = 0;
                 }
+                else if ((KeyCode)c == ModInput.GetBindingKey("ToggleConsole")) ; // if we hit the toggle key, don't print anything
                 else
                 {
                     CurrentCmd = CurrentCmd.Insert(EditLocation, c.ToString());
@@ -677,6 +682,44 @@ namespace PiTung.Console
 
                 return str;
             }
+        }
+
+        /// <summary>
+        /// Saves the contents of the command when TriggetAutocompletion() was last called
+        /// If it is the same, the next call to TriggerAutocompletion will log the 
+        /// autocompletion candidates if there are multiple
+        /// </summary>
+        private static String PreviousCmd = "";
+
+        /// <summary>
+        /// Attempts to autocomplete the current word
+        /// </summary>
+        private static void TriggerAutocompletion()
+        {
+            if (CurrentCmd == "") // Nothing to work with
+                return;
+            if (CurrentCmd.IndexOf(" ") >= 0) // Not autocompleting the verb
+                return;
+            List<String> candidates =
+                new List<String>(Autocompletion.Candidates(CurrentCmd, Registry.Keys));
+            if (candidates.Count() == 0)
+                return;
+
+            if (candidates.Count() == 1)
+            {
+                CurrentCmd = candidates[0] + " ";
+                EditLocation = CurrentCmd.Length;
+                return;
+            }
+
+            if (PreviousCmd == CurrentCmd)
+            {
+                String list = "";
+                foreach (String candidate in candidates)
+                    list += candidate + " ";
+                Log(candidates);
+            }
+            PreviousCmd = CurrentCmd;
         }
 
         private static float EaseOutQuad(float start, float end, float value)

--- a/PiTung Bootstrap.csproj
+++ b/PiTung Bootstrap.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Components\IOMap.cs" />
     <Compile Include="Components\SaveThisAttribute.cs" />
     <Compile Include="ConfigurationFile.cs" />
+    <Compile Include="Console\Autocompletion.cs" />
     <Compile Include="Mod utilities\Configuration.cs" />
     <Compile Include="Mod utilities\Hologram.cs" />
     <Compile Include="Mod utilities\HologramManager.cs" />


### PR DESCRIPTION
The command name (verb) can now be autocompleted when pressing a key.
Here are the changes:
  * Default console toggle key changed from `Tab` to `BackQuote`
  * New input binding `"ConsoleAutocompletion"`, default is `Tab`
  * When multiple autocompletions are possible, pressing the autocompletion key twice will log a list of the candidates
  * Fixed a bug where using a printable character key as a console toggle would input said character