### PR TITLE
Full autocompletion

### DIFF
--- a/Console/CmdParser.cs
+++ b/Console/CmdParser.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace PiTung.Console
 {
@@ -59,6 +61,112 @@ namespace PiTung.Console
 
             error = null;
             return true;
+        }
+
+        internal enum TokenType
+        {
+            WHITESPACE, // For any length of whitespace
+            QUOTE, // For the " char
+            TEXT, // For any strings not containing whitespaces
+            ERROR // Error token, when input could not be lexed
+        }
+
+        internal struct Token
+        {
+            public readonly TokenType Type;
+            public readonly String Value;
+
+            public Token(TokenType Type, String Value) {
+                this.Type = Type;
+                this.Value = Value;
+            }
+        }
+
+        internal static Regex WhiteSpace = new Regex("^\\s+");
+        internal static Regex TextMatcher = new Regex("^(?:[^\" ]|\\\\\")+"); //\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ all this to match \"
+        internal static Regex StringMatcher = new Regex("^\"(?:[^\"]|\\\\\")+\"?");
+
+        internal static Token LexToken(ref String input)
+        {
+            if(input[0] == '"')
+            {
+                input = input.Remove(0, 1);
+                return new Token(TokenType.QUOTE, "\"");
+            }
+            Match ws_match = WhiteSpace.Match(input);
+            if(ws_match.Success)
+            {
+                String matched = ws_match.Value;
+                input = input.Remove(0, matched.Length);
+                return new Token(TokenType.WHITESPACE, matched);
+            }
+            Match text_match = TextMatcher.Match(input);
+            if(text_match.Success)
+            {
+                String matched = text_match.Value;
+                input = input.Remove(0, matched.Length);
+                return new Token(TokenType.TEXT, matched);
+            }
+            return new Token(TokenType.ERROR, "");
+        }
+
+        public static IEnumerable<Token> LexString(String command)
+        {
+            String input = command;
+            List<Token> tokens = new List<Token>();
+            while(input.Length > 0)
+            {
+                Token token = LexToken(ref input);
+                if (token.Type == TokenType.ERROR)
+                    break;
+                tokens.Add(token);
+            }
+            return tokens;
+        }
+
+        public static bool EndsInsideQuotes(IEnumerable<Token> tokens)
+        {
+            return tokens
+                .Where(token => token.Type == TokenType.QUOTE)
+                .Count() % 2 == 1;
+        }
+
+        public static String Reconstruct(IEnumerable<Token> tokens)
+        {
+            String result = "";
+            foreach (Token token in tokens)
+                result += token.Value;
+            return result;
+        }
+
+        public static IEnumerable<String> ConstructArguments(IEnumerable<Token> tokens)
+        {
+            bool in_quotes = false;
+            List<String> arguments = new List<String>();
+            String current = "";
+            foreach (Token token in tokens)
+            {
+                if(token.Type == TokenType.QUOTE)
+                {
+                    if(in_quotes)
+                    {
+                        arguments.Add(current);
+                        current = "";
+                    }
+
+                    in_quotes = !in_quotes;
+                }
+                else if(in_quotes)
+                    current += token.Value;
+                else if(token.Type == TokenType.TEXT)
+                    arguments.Add(token.Value);
+            }
+            return arguments;
+        }
+
+        public static IEnumerable<String> PartialParse(String command)
+        {
+            return ConstructArguments(LexString(command));
         }
     }
 }

--- a/Console/InternalCommands.cs
+++ b/Console/InternalCommands.cs
@@ -115,6 +115,12 @@ namespace PiTung.Console
             SetVariable(variable, value);
             return true;
         }
+
+        public override IEnumerable<String> AutocompletionCandidates(IEnumerable<String> arguments) {
+            if(arguments.Count() != 1)
+                return new List<String>();
+            return Autocompletion.Candidates(arguments.ElementAt(0), IGConsole.GetVariables());
+        }
     }
 
     internal class Command_get : Command
@@ -143,6 +149,12 @@ namespace PiTung.Console
             }
 
             return false;
+        }
+
+        public override IEnumerable<String> AutocompletionCandidates(IEnumerable<String> arguments) {
+            if(arguments.Count() != 1)
+                return new List<String>();
+            return Autocompletion.Candidates(arguments.ElementAt(0), IGConsole.GetVariables());
         }
     }
 

--- a/Console/InternalCommands.cs
+++ b/Console/InternalCommands.cs
@@ -48,7 +48,8 @@ namespace PiTung.Console
                 Command command;
                 if (Registry.TryGetValue(name, out command))
                 {
-                    Log(command.Description);
+                    if(command.Description != null)
+                        Log(command.Description);
                     Log("<b>Usage:</b> " + command.Usage);
                 }
                 else
@@ -70,6 +71,12 @@ namespace PiTung.Console
                     log += ": " + command.Description;
                 return log;
             }
+        }
+
+        public override IEnumerable<String> AutocompletionCandidates(IEnumerable<String> arguments) {
+            if(arguments.Count() != 1)
+                return new List<String>();
+            return Autocompletion.Candidates(arguments.ElementAt(0), IGConsole.GetCommandNames());
         }
     }
 
@@ -180,6 +187,12 @@ namespace PiTung.Console
             {
                 return false;
             }
+        }
+
+        public override IEnumerable<String> AutocompletionCandidates(IEnumerable<String> arguments) {
+            if(arguments.Count() != 1)
+                return new List<String>();
+            return Autocompletion.Candidates(arguments.ElementAt(0), Mod.AliveMods.Select(mod => mod.Name));
         }
 
         private bool ReloadMod(string name)


### PR DESCRIPTION
Autocompletion is now supported for command arguments (including arguments in quotations)
  * Added virtual `AutocompletionCandidates` method to `Command` to query commands about autocompletion
  * Added autocompletion support for `help`, `get`, `set` and `reload`
  * Unrelated: fixed a bug in the `help` command where the command would fail if invoked on a command that did not override `Description`